### PR TITLE
Export Store<T> and StoreConfig<T>

### DIFF
--- a/src/Store.luau
+++ b/src/Store.luau
@@ -133,7 +133,7 @@ type ListVersionParams = {
 	pageSize: number?,
 }
 
-type StoreImpl<T> = {
+export type StoreImpl<T> = {
 	__index: StoreImpl<T>,
 
 	-- Internal helper methods

--- a/src/init.luau
+++ b/src/init.luau
@@ -8,9 +8,15 @@
 	Users of the library should typically only need to require this top-level module.
 ]=]
 
+local Types = require(script.Types)
 local Log = require(script.Log)
 local Migrations = require(script.Migrations)
-local PlayerStore = require(script.PlayerStore)
+local Store = require(script.Store)
+
+export type Store<T> = Store.StoreImpl<T>
+export type StoreConfig<T> = Store.StoreConfig<T>
+
+export type MigrationStep = Types.MigrationStep
 
 --[=[
 	Provides helper functions for creating common migration steps.


### PR DESCRIPTION
This PR exports some types, which makes integrating loosely types codebases easier because it lets you cast Lyra's API.

Closes issue #10 