### PR TITLE
Fix network updates callback example

### DIFF
--- a/docs/advanced/networking.md
+++ b/docs/advanced/networking.md
@@ -19,7 +19,7 @@ Here's a basic example:
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local Network = require(ReplicatedStorage.Network)
 
-local function syncWithClient(key: string, newData, oldData)
+local function syncWithClient(key: string, oldData, newData)
     local player = Players:GetPlayerByUserId(tonumber(key))
     if not player then return end
 


### PR DESCRIPTION
The docs in networking have the example with a callback with params as `(key: string, newData, oldData)` when instead it should be `(key: string, oldData, newData)`