### PR TITLE
Fix: Prevent exponential orphan file growth in Session:orphanFile()

### DIFF
--- a/src/Session.luau
+++ b/src/Session.luau
@@ -591,6 +591,13 @@ function Session:orphanFile(file: Types.File): ()
 	end
 	local logger = self.ctx.logger:extend({ method = "orphanFile", key = self.key, shard = file.shard })
 
+	for _, existingFile in self.orphanedFiles do
+		if Tables.equalsDeep(file, existingFile) then
+			logger:log("trace", "file already in orphaned list, skipping", { file = file })
+			return
+		end
+	end
+
 	logger:log("trace", "adding file to orphaned list", { file = file })
 	-- Add to list immediately so `writeRecord` includes it if it runs concurrently.
 	table.insert(self.orphanedFiles, file)


### PR DESCRIPTION
When saving large sharded data (>4MB), failed `writeRecord` attempts were causing exponential growth in the orphaned files list, leading to thousands of DataStore deletion requests until throttling. This unintended behavior would completely break data sharding.

Added a duplicate check at the beginning of `Session:orphanFile()` to prevent the same file from being added to the orphaned files list multiple times.

This ensures that even if `orphanFile` is called multiple times for the same file during retry scenarios, it will only be added once, preventing the exponential growth.

- Tested with large data (>4MB requiring sharding)
- Verified retry scenarios no longer cause exponential orphan growth
- Confirmed DataStore request count remains reasonable during failures