### PR TITLE
Performance improvements for immutable updates

### DIFF
--- a/src/Session.luau
+++ b/src/Session.luau
@@ -1008,12 +1008,22 @@ local function updateInternal(
 		end
 
 		-- Ensure the new data is frozen
-		Tables.freezeDeep(nextData :: any)
+		if immutable then
+		    -- POTENTIALLY UNSAFE: Assume that if a table is frozen, all tables underneath it are also frozen.
+    		-- This improves performance for immutable updates at the cost of potentially not freezing some tables, be it user intention or error.
+		    Tables.refreezeDeep(nextData :: any)
+		else
+		    Tables.freezeDeep(nextData :: any)
+		end
 
 		-- Check if the data actually changed
-		if Tables.equalsDeep(nextData :: any, currentData :: any) then
-			logger:log("trace", "transform resulted in no data change, resolving true")
-			return resolve(true) -- Considered successful, but data remains same
+		-- We probably don't want to use Tables.equalsDeep if we're not in an immutable context
+		if
+		    (immutable and Tables.immutableEqualsDeep(nextData :: any, currentData :: any))
+			or (immutable == false and Tables.equalsDeep(nextData :: any, currentData :: any))
+		then
+    		logger:log("trace", "transform resulted in no data change, resolving true")
+    		return resolve(true) -- Considered successful, but data remains same
 		end
 
 		if immutable == false then

--- a/src/Session.luau
+++ b/src/Session.luau
@@ -61,8 +61,8 @@ local noYield = require(script.Parent.noYield)
 	.isSaved (self: Session<T>) -> boolean
 
 	-- Internal state mutation
-	.setData (self: Session<T>, data: T) -> ()
-	.mutateKey (self: Session<T>, newData: T) -> ()
+	.setData (self: Session<T>, data: T, immutableUpdate: boolean?) -> ()
+	.mutateKey (self: Session<T>, newData: T, immutableUpdate: boolean?) -> ()
 
 	-- Autosave management
 	.startAutosaving (self: Session<T>) -> ()
@@ -81,8 +81,8 @@ type SessionImpl<T> = {
 	orphanFile: (self: Session<T>, file: Types.File) -> (),
 	writeRecord: (self: Session<T>, txInfo: Types.TxInfo) -> Promise.TPromise<any>,
 	isSaved: (self: Session<T>) -> boolean,
-	setData: (self: Session<T>, data: T) -> (),
-	mutateKey: (self: Session<T>, newData: T) -> (),
+	setData: (self: Session<T>, data: T, immutableUpdate: boolean?) -> (),
+	mutateKey: (self: Session<T>, newData: T, immutableUpdate: boolean?) -> (),
 	startAutosaving: (self: Session<T>) -> (),
 	stopAutosaving: (self: Session<T>) -> (),
 	unload: (self: Session<T>) -> Promise.Promise,
@@ -778,13 +778,19 @@ end
 	@within Session
 	@private
 	@param data any -- The new data value.
+	@param immutableUpdate boolean? -- Whether this originates from an immutable data update. This triggers a faster freeze function.
 ]=]
-function Session:setData(data: any): ()
+function Session:setData(data: any, immutableUpdate: boolean?): ()
 	-- Generate a unique ID for this mutation and add it to the changeSet.
 	local mutationId = HttpService:GenerateGUID(false)
 	self.changeSet[mutationId] = true
-	-- Freeze and update the data reference.
-	Tables.freezeDeep(data)
+	-- Make sure the data is frozen and update the data reference.
+	if immutableUpdate == true then
+	    -- POTENTIALLY UNSAFE: See function doc comment
+	    Tables.ensureFrozen(data)
+	else
+	    Tables.freezeDeep(data)
+	end
 	self.data = data
 end
 
@@ -795,12 +801,13 @@ end
 	@within Session
 	@private
 	@param newData any -- The new data value.
+	@param immutableUpdate boolean? -- Whether this originates from an immutable data update. This triggers a faster freeze function.
 ]=]
-function Session:mutateKey(newData: any): ()
+function Session:mutateKey(newData: any, immutableUpdate: boolean?): ()
 	local oldData = self.data -- Store reference to previous data
 
 	-- Update internal data (sets .data and marks changeSet)
-	self:setData(newData)
+	self:setData(newData, immutableUpdate)
 
 	-- Trigger change callbacks asynchronously
 	for _, callback in self.ctx.changedCallbacks do
@@ -1009,9 +1016,8 @@ local function updateInternal(
 
 		-- Ensure the new data is frozen
 		if immutable then
-		    -- POTENTIALLY UNSAFE: Assume that if a table is frozen, all tables underneath it are also frozen.
-    		-- This improves performance for immutable updates at the cost of potentially not freezing some tables, be it user intention or error.
-		    Tables.refreezeDeep(nextData :: any)
+		    -- POTENTIALLY UNSAFE: See function doc comment
+		    Tables.ensureFrozen(nextData :: any)
 		else
 		    Tables.freezeDeep(nextData :: any)
 		end
@@ -1031,7 +1037,7 @@ local function updateInternal(
 		end
 
 		-- Data changed and is valid, apply the mutation
-		self:mutateKey(nextData)
+		self:mutateKey(nextData, immutable)
 
 		logger:log("trace", "update applied successfully")
 

--- a/src/Session.luau
+++ b/src/Session.luau
@@ -1024,6 +1024,7 @@ local function updateInternal(
 
 		-- Check if the data actually changed
 		-- We probably don't want to use Tables.equalsDeep if we're not in an immutable context
+		-- POTENTIALLY UNSAFE: See function doc comment for Tables.immutableEqualsDeep
 		if
 		    (immutable and Tables.immutableEqualsDeep(nextData :: any, currentData :: any))
 			or (immutable == false and Tables.equalsDeep(nextData :: any, currentData :: any))

--- a/src/Tables.luau
+++ b/src/Tables.luau
@@ -98,6 +98,30 @@ local function equalsDeep(a: { [any]: any }, b: { [any]: any }): boolean
 	return true
 end
 
+local function immutableEqualsDeep(a: { [any]: any }, b: { [any]: any }): boolean
+	if typeof(a) ~= "table" or typeof(b) ~= "table" then
+		return a == b
+	end
+	
+	if table.isfrozen(a) or table.isfrozen(b) then
+	    return a == b
+	end
+
+	for key, value in a do
+		if not equalsDeep(value, b[key]) then
+			return false
+		end
+	end
+
+	for key, value in b do
+		if not equalsDeep(value, a[key]) then
+			return false
+		end
+	end
+
+	return true
+end
+
 local function freezeDeep<T>(t: T): ()
 	if typeof(t) ~= "table" then
 		return
@@ -112,6 +136,22 @@ local function freezeDeep<T>(t: T): ()
 			freezeDeep(value)
 		end
 	end
+end
+
+local function refreezeDeep<T>(t: T): ()
+    if typeof(t) ~= "table" then
+        return
+    end
+    
+    if table.isfrozen(t) == true then
+        return
+    end
+    
+    table.freeze(t)
+    
+    for _, value in t :: any do
+        refreezeDeep(value)
+    end
 end
 
 -- Performs a deep reconciliation of a target table with a source table,
@@ -223,7 +263,9 @@ return {
 	mergeDeep = mergeDeep,
 	mergeShallow = mergeShallow,
 	equalsDeep = equalsDeep,
+	immutableEqualsDeep = immutableEqualsDeep,
 	freezeDeep = freezeDeep,
+	refreezeDeep = refreezeDeep,
 	map = map,
 	reconcileDeep = reconcileDeep,
 }

--- a/src/Tables.luau
+++ b/src/Tables.luau
@@ -138,7 +138,9 @@ local function freezeDeep<T>(t: T): ()
 	end
 end
 
-local function refreezeDeep<T>(t: T): ()
+--- POTENTIALLY UNSAFE: Assume that if a table is frozen, all tables underneath it are also frozen.
+--- This improves performance for immutable updates at the cost of potentially not freezing some tables, be it user intention or error.
+local function ensureFrozen<T>(t: T): ()
     if typeof(t) ~= "table" then
         return
     end
@@ -150,7 +152,7 @@ local function refreezeDeep<T>(t: T): ()
     table.freeze(t)
     
     for _, value in t :: any do
-        refreezeDeep(value)
+        ensureFrozen(value)
     end
 end
 
@@ -265,7 +267,7 @@ return {
 	equalsDeep = equalsDeep,
 	immutableEqualsDeep = immutableEqualsDeep,
 	freezeDeep = freezeDeep,
-	refreezeDeep = refreezeDeep,
+	ensureFrozen = ensureFrozen,
 	map = map,
 	reconcileDeep = reconcileDeep,
 }

--- a/src/Tables.luau
+++ b/src/Tables.luau
@@ -98,6 +98,7 @@ local function equalsDeep(a: { [any]: any }, b: { [any]: any }): boolean
 	return true
 end
 
+-- POTENTIALLY UNSAFE: If the original, unmodified data isn't ensured to be completely frozen, non-frozen tables within frozen tables won't be able to be detected as changed, be it user intention or error.
 local function immutableEqualsDeep(a: { [any]: any }, b: { [any]: any }): boolean
 	if typeof(a) ~= "table" or typeof(b) ~= "table" then
 		return a == b


### PR DESCRIPTION
In immutable updates, deep freezing data and checking for deep equality is needlessly expensive.
Since data is supposed to be immutable:
- Traversing both the old data and new data in its entirety to check whether it's been updated can be cut down into just the standard Luau equality check for tables which compares memory addresses, as long as at least the old data is frozen. The user has to clone each table they want to modify, and so the memory addresses being different would always signify inequality while them being the same would always signify equality.
- Traversing the entire data and freezing every single table is very wasteful, as in a very large majority of cases only a portion of the data is modified. Adding an is frozen check for every table prior to freezing and traversing it would make it nearly free, while also letting the user make it completely free if they freeze the modified data themselves or via an immutable tables libary.

However, both of these faster methods can potentially fail, if the user intentionally or through an error in their code freezes a table, but doesn't a descendant table of it. This could partially be solved via some form of debug setting which also validates the data as completely frozen. Alternatively, this wouldn't be a debug setting and instead a *relatively to the current behaviour* inexpensive check which always happens.

For testing purposes, the changes in this PR have been made available @ `mark-marks/lyra@0.6.1-rc.1`