### PR TITLE
Fix UpdateAsync version hour comparison

### DIFF
--- a/src/MockDataStoreService.luau
+++ b/src/MockDataStoreService.luau
@@ -330,7 +330,7 @@ function MockDataStore:UpdateAsync(key, transformFunction)
 		local versions = getVersionsForKey(self, key)
 		local currentHour = getUtcHour()
 
-		if #versions == 0 or versions[#versions].CreatedTime ~= currentHour then
+		if #versions == 0 or msToHours(versions[#versions].CreatedTime) ~= currentHour then
 			table.insert(
 				versions,
 				createVersion(newValue, newUserIds or keyInfo:GetUserIds(), newMetadata or keyInfo:GetMetadata())


### PR DESCRIPTION
## Summary
- Compare UpdateAsync() version timestamps using msToHours(...), matching SetAsync().
- Prevent same-hour UpdateAsync() writes from always creating a new version because milliseconds were compared directly to an hour bucket.

## Why
CreatedTime is stored as a Unix timestamp in milliseconds, while currentHour is produced by getUtcHour(). SetAsync() already converts CreatedTime with msToHours() before comparing, so UpdateAsync() should do the same.

## Testing
- Not run locally; this is a one-line consistency fix matching the existing SetAsync() versioning logic.
